### PR TITLE
Don't import h5py._hl.base.py3

### DIFF
--- a/pyh5md/utils.py
+++ b/pyh5md/utils.py
@@ -16,7 +16,7 @@ import h5py
 import h5py.version
 from h5py import h5s, h5t, h5r, h5d
 from h5py._hl import dataset
-from h5py._hl.base import HLObject, py3
+from h5py._hl.base import HLObject
 from h5py._hl import filters
 from h5py._hl import selections as sel
 from h5py._hl import selections2 as sel2


### PR DESCRIPTION
Two good reasons:
1) It no longer exists in recent h5py releases.
2) pyh5md doesn't use it.