### PR TITLE
Import of pyh5md cause exit(1) when h5py was not present

### DIFF
--- a/pyh5md/__init__.py
+++ b/pyh5md/__init__.py
@@ -15,11 +15,7 @@ for storing molecular data (structures of biophysical compounds, molecular
 dynamics simulations, ...).
 """
 
-try:
-    import h5py
-except ImportError:
-    print "pyh5md requires the h5py library."
-    exit()
+import h5py
 
 from core import *
 

--- a/pyh5md/utils.py
+++ b/pyh5md/utils.py
@@ -16,7 +16,7 @@ import h5py
 import h5py.version
 from h5py import h5s, h5t, h5r, h5d
 from h5py._hl import dataset
-from h5py._hl.base import HLObject, py3
+from h5py._hl.base import HLObject
 from h5py._hl import filters
 from h5py._hl import selections as sel
 from h5py._hl import selections2 as sel2


### PR DESCRIPTION
IMHO that is not expected behaviour from a library to stop executing the code. Instead a proper exception should be thrown.